### PR TITLE
Remove Devise authenticate_user!

### DIFF
--- a/app/controllers/tail/logs_controller.rb
+++ b/app/controllers/tail/logs_controller.rb
@@ -1,30 +1,29 @@
 require_dependency "tail/application_controller"
 
 module Tail
-  class LogsController < ApplicationController
-    before_filter :authenticate_user! if defined? Devise
-    attr_reader :web_logger
+    class LogsController < ApplicationController
+        attr_reader :web_logger
 
-    def index
-      @files = tail
-    end
+        def index
+            @files = tail
+        end
 
-    def grep
-      @files = tail
-      render '_main'
-    end
+        def grep
+            @files = tail
+            render '_main'
+        end
 
-    def tail
-      @web_logger ||= Tail::Log.instance
-      @web_logger.n = params[:n]
-      params[:n] = @web_logger.n
-      log_file_name = params[:file_name] || "#{Rails.env}.log"
-      @web_logger.tail(log_file_name)
+        def tail
+            @web_logger ||= Tail::Log.instance
+            @web_logger.n = params[:n]
+            params[:n] = @web_logger.n
+            log_file_name = params[:file_name] || "#{Rails.env}.log"
+            @web_logger.tail(log_file_name)
+        end
+        def flush
+            web_logger ||= Tail::Log.instance
+            web_logger.flush(params[:file_name])
+            redirect_to action: :index
+        end
     end
-    def flush
-      web_logger ||= Tail::Log.instance
-      web_logger.flush(params[:file_name])
-      redirect_to action: :index
-    end
-  end
 end


### PR DESCRIPTION
No need for authenticating user in controller.
Firstly, if you need devise authentication for tail, you can use
```
        authenticate :user do
            mount Tail::Engine => "/tail"
        end
```
Secondly, if your model is not named User, but anything else, like
Admin, there will be no method authenticate_user!, there will be only
authenticate_admin!. So it will throw an error.